### PR TITLE
Cross currency/cryptocurrency conversion and currency endpoint change

### DIFF
--- a/__tests__/convert.ts
+++ b/__tests__/convert.ts
@@ -14,7 +14,7 @@ test("Convert MXN to GBP", async () => {
 
 test("Do not convert unknown currency to EUR", () => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
+  // @ts-ignore
   convert("unknown currency", 10, "EUR").catch((err) => {
     expect(err).toBe("Cannot convert unknown currency to EUR");
   });
@@ -25,3 +25,15 @@ test("Convert ETH to BTC", async () => {
   expect(conversion).toHaveProperty("currency");
   expect(conversion).toHaveProperty("amount");
 });
+
+test("Convert USD to ETH", async () => {
+  const conversion = await convert("USD", 1, "ETH");
+  expect(conversion).toHaveProperty("currency");
+  expect(conversion).toHaveProperty("amount");
+});
+
+test("Convert BTC to USD", async () => {
+  const conversion = await convert("BTC", 1, "USD");
+  expect(conversion).toHaveProperty("currency");
+  expect(conversion).toHaveProperty("amount");
+})

--- a/__tests__/convert.ts
+++ b/__tests__/convert.ts
@@ -16,7 +16,7 @@ test("Do not convert unknown currency to EUR", () => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   convert("unknown currency", 10, "EUR").catch((err) => {
-    expect(err).toBe("Cannot convert unknown currency to EUR");
+    expect(err).toBe("Invalid Currency (UNKNOWN CURRENCY)");
   });
 });
 

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -1,8 +1,6 @@
 import { Currency } from "../types/currencies";
 import axios from "axios";
-import { isCurrency } from "../utils/currencies";
 import { CryptoCurrency } from "../types/cryptocurrencies";
-import { isCryptoCurrency } from "../utils/cryptocurrencies";
 
 /**
  * Converts one currency to another.

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -17,14 +17,15 @@ export function convert(
   toCurrency: Currency | CryptoCurrency
 ): Promise<{ currency: Currency | CryptoCurrency; amount: number }> {
   return new Promise((resolve, reject) => {
-    if (!isCurrency(fromCurrency) && !isCurrency(toCurrency) && !isCryptoCurrency(fromCurrency) && !isCryptoCurrency(toCurrency)) {
-      return reject(`Cannot convert ${fromCurrency} to ${toCurrency}`);
-    } else {
+      if (fromCurrency === toCurrency) {
+        return reject("fromCurrency cannot be the same as toCurrency");
+      }
       axios
         .get(`https://api.coinbase.com/v2/exchange-rates?currency=${ fromCurrency }`)
         .then((body) => {
           return resolve({ currency:  toCurrency, amount: amount * body.data.data.rates[toCurrency]})
-        });
-    }
+        }).catch((err) => {
+          return reject(err.response.data.errors[0].message);
+      })
   });
 }

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -17,26 +17,14 @@ export function convert(
   toCurrency: Currency | CryptoCurrency
 ): Promise<{ currency: Currency | CryptoCurrency; amount: number }> {
   return new Promise((resolve, reject) => {
-    if (isCurrency(fromCurrency) && isCurrency(toCurrency)) {
-      axios
-        .get(`https://api.exchangeratesapi.io/latest?base=${fromCurrency}`)
-        .then((body) => {
-          return resolve({ currency: toCurrency, amount: amount * body.data.rates[toCurrency] });
-        })
-        .catch((err) => {
-          return reject(err.response.data.error);
-        });
-    } else if (isCryptoCurrency(fromCurrency) && isCryptoCurrency(toCurrency)) {
-      axios
-        .get(`https://api.coinbase.com/v2/exchange-rates?currency=${fromCurrency}`)
-        .then((body) => {
-          return resolve({ currency: toCurrency, amount: amount * body.data.data.rates[toCurrency] });
-        })
-        .catch((err) => {
-          return reject(err.response.data);
-        });
-    } else {
+    if (!isCurrency(fromCurrency) && !isCurrency(toCurrency) && !isCryptoCurrency(fromCurrency) && !isCryptoCurrency(toCurrency)) {
       return reject(`Cannot convert ${fromCurrency} to ${toCurrency}`);
+    } else {
+      axios
+        .get(`https://api.coinbase.com/v2/exchange-rates?currency=${ fromCurrency }`)
+        .then((body) => {
+          return resolve({ currency:  toCurrency, amount: amount * body.data.data.rates[toCurrency]})
+        });
     }
   });
 }


### PR DESCRIPTION
# Cross currency/cryptocurrency conversion and currency endpoint change
This pull request should resolve the issue of not being able to convert BTC to USD, as well as the issue with the previous currency conversion endpoint requiring an API key to use.

##  Change in the currency (non-crypto) endpoint
The endpoint used for currencies requires an API key. I'm not sure if this is a new feature of theirs, however, it's a bit annoying. While running tests, I came upon this error:

### Test 1
```ts
test('Test USD to EUR', async () => {
  const res = await convert('USD', 1, 'EUR');
  expect(res).toBeDefined();
})
```

### Response 1
```
TypeError: Cannot read property 'data' of undefined
```

<hr />

Naturally, I thought I messed something up. Since I was working on this function invoked (`convert`), I went to check my logic to make sure that the (non crypto) currency to currency tests weren't being passed to the wrong part of the function. When I discovered they were not, I went to the project I was working on that depends on this package. I ran the same test there, to receive the same error.

When investigating the response back from the endpoint `"https://api.exchangeratesapi.io/latest?"`, I essentially received this:

```json
      data: {
        success: false,
        error: {
          code: 101,
          type: 'missing_access_key',
          info: 'You have not supplied an API Access Key. [Required format: access_key=YOUR_ACCESS_KEY]'
        }
      }
```

Which is appropriately the same response you will get when visiting the endpoint in the [browser](https://api.exchangeratesapi.io/latest?). 

## Proposition
In this pull request, I move the current endpoint (api.exchangeratesapi.io) to the Coinbase API's endpoint. Interestingly enough, the Coinbase API allows conversion between cryptocurrency and (fiat 🤣) currency easily, allowing the entire function to be short. The function's logic now allows conversion between cryptocurrency and normal currency. 

### Advantages of this PR
* There will no longer be the need for two endpoints
* There is not the necessity of setting up the package with an API key
* The `convert` function is now shorter, around the length of the pre-crypto version of the function
* All tests seemingly pass